### PR TITLE
fix: remove generated code

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -76,6 +76,7 @@ jobs:
 
       - name: Generate API docs
         run: |
+          find $(cat PACKAGE) -mindepth 1 ! -name 'py.typed' -delete
           java -jar openapi-generator-cli.jar generate -c openapitools.json
 
       - name: Git Setup


### PR DESCRIPTION
fix: Remove generated code (except py.typed) before generating a new version, since openapi generator does not do that itself.
We need to do this to prevent removed endpoints form staying in generated code.