### PR TITLE
fix: replace runners

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   generate-api-docs:
     name: Update version and build python module
-    runs-on: default
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
@@ -94,7 +94,7 @@ jobs:
 
   build-release:
     name: Build release distribution
-    runs-on: default
+    runs-on: ubuntu-latest
     needs: generate-api-docs
     env:
       UV_VERSION: 0.5.21
@@ -134,7 +134,7 @@ jobs:
 
   pypi-publish:
     name: Publish to PyPI
-    runs-on: default
+    runs-on: ubuntu-latest
     needs: build-release
     environment:
       name: pypi


### PR DESCRIPTION
fix: replace runners with ubuntu-latest, since we can't use our own runners once the repository is made public