### PR TITLE
fix: change remaining 1.2 to 1.3

### DIFF
--- a/PACKAGE
+++ b/PACKAGE
@@ -1,1 +1,1 @@
-cloudbeds_pms_v1_2
+cloudbeds_pms_v1_3

--- a/openapitools.json
+++ b/openapitools.json
@@ -3,16 +3,16 @@
     "version": "7.11.0"
   },
   "generatorName": "python",
-  "inputSpec": "public_accessa/api/v1.2/docs/cb-v1.2-openapi-3.0.1.yaml",
+  "inputSpec": "public_accessa/api/v1.3/docs/cb-v1.3-openapi-3.0.1.yaml",
   "outputDir": ".",
   "validateSpec": false,
   "additionalProperties": {
-    "packageName": "cloudbeds_pms_v1_2",
-    "projectName": "Cloudbeds PMS V1.2",
-    "packageVersion": "1.3.0",
-    "packageDescription": "OpenAPI client for Cloudbeds PMS v1.2 API.",
+    "packageName": "cloudbeds_pms_v1_3",
+    "projectName": "Cloudbeds PMS V1.3",
+    "packageVersion": "1.0.0",
+    "packageDescription": "OpenAPI client for Cloudbeds PMS v1.3 API.",
     "generateSourceCodeOnly": true,
-    "packageUrl": "https://github.com/cloudbeds/cloudbeds-api-python/tree/release/v1"
+    "packageUrl": "https://github.com/cloudbeds/cloudbeds-api-python/tree/release/v1_3"
   },
   "files": {
     "README_onlypackage.mustache": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 dynamic = ["version"]
-name = "cloudbeds_pms_v1_2"
+name = "cloudbeds_pms_v1_3"
 description = "OpenAPI client for Cloudbeds PMS v1.3 API."
 readme = "README.md"
 authors = [
@@ -38,8 +38,8 @@ classifiers = [
 requires-python = ">=3.8"
 
 [project.urls]
-Documentation = "https://github.com/cloudbeds/cloudbeds-api-python/tree/release/v1#README"
-Repository = "https://github.com/cloudbeds/cloudbeds-api-python/tree/release/v1"
+Documentation = "https://github.com/cloudbeds/cloudbeds-api-python/tree/release/v1_3#README"
+Repository = "https://github.com/cloudbeds/cloudbeds-api-python/tree/release/v1_3"
 
 [project.optional-dependencies]
 testing = [
@@ -60,4 +60,4 @@ where = ["."]
 version = { file = "VERSION" }
 
 [tool.setuptools.package-data]
-"cloudbeds_pms_v1_2" = ["py.typed"]
+"cloudbeds_pms_v1_3" = ["py.typed"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 annotated-types==0.7.0
     # via pydantic
 coverage==7.6.10
-    # via cloudbeds-pms (pyproject.toml)
+    # via cloudbeds-pms-v1-3 (pyproject.toml)
 iniconfig==2.0.0
     # via pytest
 packaging==24.2
@@ -11,19 +11,19 @@ packaging==24.2
 pluggy==1.5.0
     # via pytest
 pydantic==2.10.5
-    # via cloudbeds-pms (pyproject.toml)
+    # via cloudbeds-pms-v1-3 (pyproject.toml)
 pydantic-core==2.27.2
     # via pydantic
 pytest==8.3.4
-    # via cloudbeds-pms (pyproject.toml)
+    # via cloudbeds-pms-v1-3 (pyproject.toml)
 python-dateutil==2.9.0.post0
-    # via cloudbeds-pms (pyproject.toml)
+    # via cloudbeds-pms-v1-3 (pyproject.toml)
 six==1.17.0
     # via python-dateutil
 typing-extensions==4.12.2
     # via
-    #   cloudbeds-pms (pyproject.toml)
+    #   cloudbeds-pms-v1-3 (pyproject.toml)
     #   pydantic
     #   pydantic-core
 urllib3==2.3.0
-    # via cloudbeds-pms (pyproject.toml)
+    # via cloudbeds-pms-v1-3 (pyproject.toml)

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.8"
 resolution-markers = [
     "python_full_version >= '3.9'",
@@ -18,7 +19,7 @@ wheels = [
 ]
 
 [[package]]
-name = "cloudbeds-pms-v1-2"
+name = "cloudbeds-pms-v1-3"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
@@ -51,6 +52,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.7.1" },
     { name = "urllib3", specifier = ">=1.25.3,<3.0.0" },
 ]
+provides-extras = ["testing"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This pull request updates the project to use version 1.3 of the Cloudbeds PMS API. The changes include updates to configuration files and metadata to reflect the new API version and associated details.

### API Version Update:

* [`PACKAGE`](diffhunk://#diff-19b723bc37c15fb257166f057eb49c85ed9758acd1eae99186609e97482d9e70L1-R1): Updated the API version from `cloudbeds_pms_v1_2` to `cloudbeds_pms_v1_3`.
* [`openapitools.json`](diffhunk://#diff-8a4e6e50662bb1898f4a273a407ec8321a776f954f845fe07bc6af64a7220b4cL6-R15): Changed the OpenAPI specification file path to use the v1.3 documentation, updated the package and project names to `cloudbeds_pms_v1_3`, and adjusted the package version and description accordingly. Also updated the `packageUrl` to point to the new release branch for v1.3.

### Metadata and Configuration Updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Updated the project name from `cloudbeds_pms_v1_2` to `cloudbeds_pms_v1_3` and adjusted the description to reflect the v1.3 API.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L63-R63): Modified the package data configuration to include `py.typed` under the new package name `cloudbeds_pms_v1_3`.